### PR TITLE
ref(scripts/config.sh): split out functionality into check-vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ docker-mutable-push:
 
 image:
 	export E2E_RUNNER_IMAGE=${IMAGE}
+
+test:
+	bats tests/

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. "${DIR}/functions.sh"
+
 export HELM_REMOTE_REPO="${HELM_REMOTE_REPO:-https://github.com/deis/charts.git}"
 export DEIS_CHART_HOME=$HELMC_HOME/cache/deis
 export WORKFLOW_BRANCH="${WORKFLOW_BRANCH:-master}"
@@ -12,62 +15,19 @@ export K8S_OBJECT_LOG="${DEIS_LOG_DIR}/k8s-objects.log"
 export DEIS_DESCRIBE="${DEIS_LOG_DIR}/deis-describe.log"
 
 # Make sure we get the env vars for the components setup
-if [ -n "${BUILDER_SHA}" ]; then
-  export "BUILDER_GIT_TAG"="git-${BUILDER_SHA:0:7}"
-  echo "Setting BUILDER_GIT_TAG to ${BUILDER_GIT_TAG}"
-fi
+components=(
+  "BUILDER"
+  "CONTROLLER"
+  "DOCKERBUILDER"
+  "FLUENTD"
+  "LOGGER"
+  "MINIO"
+  "POSTGRES"
+  "REGISTRY"
+  "ROUTER"
+  "SLUGBUILDER"
+  "SLUGRUNNER"
+  "WORKFLOW_E2E"
+)
 
-if [ -n "${CONTROLLER_SHA}" ]; then
-  export "CONTROLLER_GIT_TAG"="git-${CONTROLLER_SHA:0:7}"
-  echo "Setting CONTROLLER_GIT_TAG to ${CONTROLLER_GIT_TAG}"
-fi
-
-if [ -n "${DOCKERBUILDER_SHA}" ]; then
-  export "DOCKERBUILDER_GIT_TAG"="git-${DOCKERBUILDER_SHA:0:7}"
-  echo "Setting DOCKERBUILDER_GIT_TAG to ${DOCKERBUILDER_GIT_TAG}"
-fi
-
-if [ -n "${FLUENTD_SHA}" ]; then
-  export "FLUENTD_GIT_TAG"="git-${FLUENTD_SHA:0:7}"
-  echo "Setting FLUENTD_GIT_TAG to ${FLUENTD_GIT_TAG}"
-fi
-
-if [ -n "${LOGGER_SHA}" ]; then
-  export "LOGGER_GIT_TAG"="git-${LOGGER_SHA:0:7}"
-  echo "Setting LOGGER_GIT_TAG to ${LOGGER_GIT_TAG}"
-fi
-
-if [ -n "${MINIO_SHA}" ]; then
-  export "MINIO_GIT_TAG"="git-${MINIO_SHA:0:7}"
-  echo "Setting MINIO_GIT_TAG to ${MINIO_GIT_TAG}"
-fi
-
-if [ -n "${POSTGRES_SHA}" ]; then
-  export "POSTGRES_GIT_TAG"="git-${POSTGRES_SHA:0:7}"
-  echo "Setting POSTGRES_GIT_TAG to ${POSTGRES_GIT_TAG}"
-fi
-
-if [ -n "${REGISTRY_SHA}" ]; then
-  export "REGISTRY_GIT_TAG"="git-${REGISTRY_SHA:0:7}"
-  echo "Setting REGISTRY_GIT_TAG to ${REGISTRY_GIT_TAG}"
-fi
-
-if [ -n "$ROUTER_SHA" ]; then
-  export "ROUTER_GIT_TAG"="git-${ROUTER_SHA:0:7}"
-  echo "Setting ROUTER_GIT_TAG to ${ROUTER_GIT_TAG}"
-fi
-
-if [ -n "${SLUGBUILDER_SHA}" ]; then
-  export "SLUGBUILDER_GIT_TAG"="git-${SLUGBUILDER_SHA:0:7}"
-  echo "Setting SLUGBUILDER_GIT_TAG to ${SLUGBUILDER_GIT_TAG}"
-fi
-
-if [ -n "${SLUGRUNNER_SHA}" ]; then
-  export "SLUGRUNNER_GIT_TAG"="git-${SLUGRUNNER_SHA:0:7}"
-  echo "Setting SLUGRUNNER_GIT_TAG to ${SLUGRUNNER_GIT_TAG}"
-fi
-
-if [ -n "${WORKFLOW_E2E_SHA}" ]; then
-  export "WORKFLOW_E2E_GIT_TAG"="git-${WORKFLOW_E2E_SHA:0:7}"
-  echo "Setting WORKFLOW_E2E_GIT_TAG to ${WORKFLOW_E2E_GIT_TAG}"
-fi
+check-vars "${components[@]}"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function check-vars {
+  components_to_check=("$@")
+  for component in "${components_to_check[@]}"
+  do
+    actual_sha="${component}_SHA"
+    actual_tag="${component}_GIT_TAG"
+
+    if [ -n "${!actual_sha}" ]; then
+      export "${component}_GIT_TAG"="git-${!actual_sha:0:7}"
+      echo "Setting ${component}_GIT_TAG to ${!actual_tag}"
+    fi
+  done
+}

--- a/tests/functions_test.bats
+++ b/tests/functions_test.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/functions.sh"
+}
+
+@test "check-vars : none given" {
+  components=()
+  run check-vars "${components[@]}"
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "check-vars : none to export" {
+  components=("FOO_COMPONENT" "BAR_COMPONENT")
+  run check-vars "${components[@]}"
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "check-vars : some to export" {
+  components=("FOO_COMPONENT" "BAR_COMPONENT")
+  export FOO_COMPONENT_SHA="1234abcd"
+  run check-vars "${components[@]}"
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${output}" == "Setting ${components[0]}_GIT_TAG to git-${FOO_COMPONENT_SHA:0:7}" ]
+}
+
+@test "check-vars : all to export" {
+  components=("FOO_COMPONENT" "BAR_COMPONENT")
+  export FOO_COMPONENT_SHA="1234abcd"
+  export BAR_COMPONENT_SHA="5678efgh"
+  run check-vars "${components[@]}"
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" == "Setting ${components[0]}_GIT_TAG to git-${FOO_COMPONENT_SHA:0:7}" ]
+  [ "${lines[1]}" == "Setting ${components[1]}_GIT_TAG to git-${BAR_COMPONENT_SHA:0:7}" ]
+}


### PR DESCRIPTION
and add bats tests; `make test` cmd

Spent a little 'slack' time yesterday playing around with how to DRY up the env vars check, plus tests with 'bats'... @jchauncey has already made mention of migrating this logic away from bash, but figured this might be a handy example to have in the meantime... 
