### PR TITLE
ref(Makefile): remove obsolete "docker tag -f" flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MUTABLE_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:canary
 
 docker-build:
 	docker build -t ${IMAGE} .
-	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 docker-push: docker-immutable-push docker-mutable-push
 


### PR DESCRIPTION
This is an error with Docker 1.12.
