### PR TITLE
fix(scripts/helm.sh): exit 0 if cluster already clean

### DIFF
--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -30,5 +30,8 @@ clean_cluster() {
       fi
       echo -n . 1>&2
     done
+  elif [ $? -eq 1 ]; then
+    echo "Cluster already clean."
+    return 0
   fi
 }


### PR DESCRIPTION
As `kubectl get pods --namespace=deis | grep deis-controller` will return
an exit code of 1 if the `grep` command does not find `deis-controller`,
therefore we should just proceed as normal.
