### PR TITLE
chore(config.sh): add WORKFLOW_CLI to component list

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -30,6 +30,7 @@ components=(
   "SLUGBUILDER"
   "SLUGRUNNER"
   "WORKFLOW_E2E"
+  "WORKFLOW_CLI"
 )
 
 check-vars "${components[@]}"

--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -2,7 +2,7 @@
 
 # Check to see if deis is installed, if so uninstall it.
 clean_cluster() {
-  kubectl get pods --namespace=deis | grep deis-controller
+  kubectl get pods --namespace=deis | grep -q deis-controller
   if [ $? -eq 0 ]; then
     echo "Deis was installed so I'm removing it!"
     kubectl delete namespace "deis" &> /dev/null
@@ -12,8 +12,8 @@ clean_cluster() {
     local waited_time=0
 
     echo "Waiting for namespace to go away!"
-    while [ ${waited_time} -lt ${timeout_secs} ]; do
-      kubectl get ns | grep deis
+    while [ ${waited_time} -lt "${timeout_secs}" ]; do
+      kubectl get ns | grep -q deis
       if [ $? -gt 0 ]; then
         echo
         return 0
@@ -22,7 +22,7 @@ clean_cluster() {
       sleep ${increment_secs}
       (( waited_time += increment_secs ))
 
-      if [ ${waited_time} -ge ${timeout_secs} ]; then
+      if [ ${waited_time} -ge "${timeout_secs}" ]; then
         echo "Namespace was never deleted"
         delete_lease
         exit 1

--- a/tests/stub.bash
+++ b/tests/stub.bash
@@ -9,13 +9,13 @@ stub() {
   main="${2}"
   exit_code="${3}"
 
-  stub_template=$(cat <<EOF
+  stub_template="\
     #!/bin/bash
     set -eo pipefail
 
     ${main}
     exit ${exit_code}
-EOF)
+"
 
   echo "${stub_template}" > ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}/${1}
   chmod +x ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}/${1}


### PR DESCRIPTION
So that commits in the workflow-cli repo can be tested via e2e;
also fix unit tests.

Ref https://github.com/deis/workflow-cli/pull/121
