### PR TITLE
fix(debug.sh): must cat <filename> to get contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
 MUTABLE_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:canary
 
 BATS_CMD := bats --tap tests
+SHELLCHECK_CMD := shellcheck -e SC1091 -e SC2002 scripts/*
 # -e SC1091 exempts `source relative/path/to/file` errors
-SHELLCHECK_CMD := shellcheck -e SC1091 scripts/*
+# -e SC2002 exempts `Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.``
 TEST_ENV_PREFIX := docker run --rm -v ${CURDIR}:/bash -w /bash quay.io/deis/shell-dev
 
 docker-build:

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -3,6 +3,6 @@
 function print-out-running-images {
   echo "Running the following Images:"
   if [ -s "${DEIS_DESCRIBE}" ]; then
-    echo "${DEIS_DESCRIBE}" | grep Image:
+    cat "${DEIS_DESCRIBE}" | grep Image:
   fi
 }


### PR DESCRIPTION
Fixes empty debug output due to bug introduced in https://github.com/deis/e2e-runner/pull/26

Sample output with bug:

```
12:04:22 Running kubectl describe pods and piping the output to /home/jenkins/logs/deis-describe.log
12:04:23 Running the following Images:
12:04:23 Health check deis until its completely up!
```
