### PR TITLE
chore(Dockerfile): increase cluster lease duration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/deis/base:0.2.0
 
-ENV CLUSTER_DURATION=800
+ENV CLUSTER_DURATION=1600
 ENV KUBECONFIG=/home/jenkins/kubeconfig.yaml
 ENV GINKGO_NODES=30
 ENV HELMC_HOME=/home/jenkins/.helmc


### PR DESCRIPTION
The former `CLUSTER_DURATION` of 800 (seconds) may sometimes be slightly too short on account of a growing e2e suite.
