### PR TITLE
fix(wait-for-router): log ip of router

### DIFF
--- a/scripts/deis.sh
+++ b/scripts/deis.sh
@@ -57,6 +57,8 @@ wait-for-router() {
   local waited_time=0
   local command_output
 
+  echo "Waiting for router at $(get-router-ip)"
+
   while [ ${waited_time} -lt ${timeout_secs} ]; do
     command_output="$(curl -sSL -o /dev/null -w '%{http_code}' "$(get-router-ip)")"
     if [ "${command_output}" == "404" ]; then


### PR DESCRIPTION
Right now, we're getting this message

```
08:33:21 Checking to see if the workflow has come up properly.
08:33:22 curl: (3) <url> malformed
08:33:24 .curl: (3) <url> malformed
08:33:25 .curl: (3) <url> malformed
08:33:27 .curl: (3) <url> malformed
08:33:29 .curl: (3) <url> malformed
08:33:30 .curl: (3) <url> malformed
08:33:48 .Successfully interacted with Deis platform 10 time(s).
```

I'd like to log the router IP before trying to communicate with it so that it's clear what's causing the malformed IP issue.
