### PR TITLE
feat(Makefile): pass along WORKFLOW_* env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DEIS_REGISTRY ?= quay.io/
 IMAGE_PREFIX ?= deisci
 IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
 MUTABLE_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:canary
+CLI_VERSION ?= latest
 
 BATS_CMD := bats --tap tests
 SHELLCHECK_CMD := shellcheck -e SC1091 -e SC2002 scripts/*
@@ -15,7 +16,13 @@ TEST_ENV_PREFIX := docker run --rm -v ${CURDIR}:/bash -w /bash quay.io/deis/shel
 build: docker-build
 push: docker-push
 run:
-	docker run -e AUTH_TOKEN=${AUTH_TOKEN} ${IMAGE}
+	docker run -e AUTH_TOKEN="${AUTH_TOKEN}" \
+		-e WORKFLOW_BRANCH="${WORKFLOW_BRANCH}" \
+		-e WORKFLOW_E2E_BRANCH="${WORKFLOW_E2E_BRANCH}" \
+		-e WORKFLOW_CHART="${WORKFLOW_CHART}" \
+		-e WORKFLOW_E2E_CHART="${WORKFLOW_E2E_CHART}" \
+		-e CLI_VERSION="${CLI_VERSION}" \
+		${IMAGE}
 
 docker-build:
 	docker build -t ${IMAGE} .


### PR DESCRIPTION
cc @jchauncey 

(if any/all `WORKFLOW_*` env vars are not declared, the code [here](https://github.com/deis/e2e-runner/blob/master/scripts/config.sh#L10-L13) already supplies defaults)

edit: also added passing through `CLI_VERSION` as it is freq aligned with the `WORKFLOW_*` env vars if a specific release.
