### PR TITLE
fix(scripts/deis.sh): wait for condition "Ready" to be true

### DIFF
--- a/scripts/deis.sh
+++ b/scripts/deis.sh
@@ -34,7 +34,7 @@ wait-for-all-pods() {
 
   local command_output
   while [ ${waited_time} -lt ${timeout_secs} ]; do
-    kubectl get pods --namespace=deis -o json | jq -r ".items[].status.conditions[0].status" | grep -q "False"
+    kubectl get pods --namespace=deis -o json | jq -r '.items[].status.conditions[] | select(.type=="Ready")' | grep -q "False"
     if [ $? -gt 0 ]; then
       echo
       echo "All pods are running!"


### PR DESCRIPTION
This was the issue preventing us from running ci/e2e-runner against `1.3x` k8s clusters.

We were checking `conditions[0]` which is "Initialized" (perhaps the index changed in k8s 1.3x),
whereas we want `conditions[1]` which is "Ready" -- to that end, the `jq` query has been
tweaked to specify `.type=="Ready"` by name so we don't fall into any array index issues in the future.

Closes https://github.com/deis/jenkins-jobs/issues/212
