### PR TITLE
fix(helm): uninstall the tiller after the e2e is run

### DIFF
--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -51,7 +51,7 @@ install_helm() {
 
 wait-for-tiller-pod-ready() {
   local name="${1}"
-  local timeout_secs=30
+  local timeout_secs=60
   local increment_secs=1
   local waited_time=0
 

--- a/scripts/lease.sh
+++ b/scripts/lease.sh
@@ -37,6 +37,11 @@ delete-lease() {
   kubectl delete namespace "deis" &> /dev/null
   echo "Deleting all test namespaces"
   kubectl get namespace | grep test | awk '{print $1}' | xargs kubectl delete namespace &> /dev/null
+  if [ -n "$USE_KUBERNETES_HELM" ]
+  then
+    echo "Uninstall the tiller"
+    kubectl delete deployment "tiller-deploy" --namespace "kube-system" &> /dev/null
+  fi
   echo "Deleting Lease for ${CLUSTER_NAME} -- ${TOKEN}"
   k8s-claimer --server="${CLAIMER_URL}" lease delete "${TOKEN}"
   return 0


### PR DESCRIPTION
Currently helm has no option/command to update the tiller image and it will give compatibility errors if the server and client are not of the same version. So deleting the tiller will create a new one during the init step.
