### PR TITLE
ref(*): transition from helmc to helm

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -5,12 +5,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . "${DIR}/functions.sh"
 
 export LEASE_RETRIES="${LEASE_RETRIES:-5}"
-export HELM_REMOTE_REPO="${HELM_REMOTE_REPO:-https://github.com/deis/charts.git}"
-export DEIS_CHART_HOME=$HELMC_HOME/cache/deis
-export WORKFLOW_BRANCH="${WORKFLOW_BRANCH:-master}"
-export WORKFLOW_E2E_BRANCH="${WORKFLOW_E2E_BRANCH:-master}"
-export WORKFLOW_CHART="${WORKFLOW_CHART:-workflow-dev}"
-export WORKFLOW_E2E_CHART="${WORKFLOW_E2E_CHART:-workflow-dev-e2e}"
 export CHART_REPO_TYPE="${CHART_REPO_TYPE:-dev}"
 export DEIS_LOG_DIR="${DEIS_LOG_DIR:-/home/jenkins/logs}"
 export K8S_EVENT_LOG="${DEIS_LOG_DIR}/k8s-events.log"
@@ -18,10 +12,16 @@ export K8S_OBJECT_LOG="${DEIS_LOG_DIR}/k8s-objects.log"
 export DEIS_DESCRIBE="${DEIS_LOG_DIR}/deis-describe.log"
 export CLAIMER_URL="${CLAIMER_URL:-k8s-claimer.champagne.deis.com}"
 
-# Make sure we get the env vars for the components setup
+# helmc-remove
+export HELM_REMOTE_REPO="${HELM_REMOTE_REPO:-https://github.com/deis/charts.git}"
+export DEIS_CHART_HOME=$HELMC_HOME/cache/deis
+export WORKFLOW_BRANCH="${WORKFLOW_BRANCH:-master}"
+export WORKFLOW_E2E_BRANCH="${WORKFLOW_E2E_BRANCH:-master}"
+export WORKFLOW_CHART="${WORKFLOW_CHART:-workflow-dev}"
+export WORKFLOW_E2E_CHART="${WORKFLOW_E2E_CHART:-workflow-dev-e2e}"
+
 repos=(
   "BUILDER"
-  "CHARTS"
   "CONTROLLER"
   "DOCKERBUILDER"
   "FLUENTD"
@@ -36,7 +36,6 @@ repos=(
   "ROUTER"
   "SLUGBUILDER"
   "SLUGRUNNER"
-  "WORKFLOW_CLI"
   "WORKFLOW_E2E"
   "WORKFLOW_MANAGER"
 )

--- a/scripts/deis.sh
+++ b/scripts/deis.sh
@@ -1,5 +1,40 @@
 #!/bin/bash
 
+# Check to see if deis is installed, if so uninstall it.
+clean_cluster() {
+  kubectl get pods --namespace=deis | grep -q deis-controller
+  if [ $? -eq 0 ]; then
+    echo "Deis was installed so I'm removing it!"
+    kubectl delete namespace "deis" &> /dev/null
+
+    local timeout_secs=${DEFAULT_TIMEOUT_SECS:-180}
+    local increment_secs=1
+    local waited_time=0
+
+    echo "Waiting for namespace to go away!"
+    while [ ${waited_time} -lt "${timeout_secs}" ]; do
+      kubectl get ns | grep -q deis
+      if [ $? -gt 0 ]; then
+        echo
+        return 0
+      fi
+
+      sleep ${increment_secs}
+      (( waited_time += increment_secs ))
+
+      if [ ${waited_time} -ge "${timeout_secs}" ]; then
+        echo "Namespace was never deleted"
+        delete-lease
+        exit 1
+      fi
+      echo -n . 1>&2
+    done
+  elif [ $? -eq 1 ]; then
+    echo "Cluster already clean."
+    return 0
+  fi
+}
+
 deis_healthcheck() {
   wait-for-all-pods "deis"
   local successes=0

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# helmc-remove (entire file)
 function check-vars {
   repos="${1}"
 
@@ -13,56 +14,4 @@ function check-vars {
       echo "Setting ${repo}_GIT_TAG to ${!actual_tag}"
     fi
   done
-}
-
-function get-chart-repo {
-  chart="${1}"
-  repo_type="${2}"
-
-  # strip '-production' if repo_type 'production'
-  echo "${chart}-${repo_type}" | sed -e 's/-production//g'
-}
-
-function set-chart-values-from-env {
-  local values_to_set
-
-  declare -A component_to_chart_map
-  component_to_chart_map+=(
-    ["BUILDER"]="builder"
-    ["CONTROLLER"]="controller"
-    ["DOCKERBUILDER"]="dockerbuilder"
-    ["FLUENTD"]="fluentd"
-    ["LOGGER"]="logger"
-    ["MINIO"]="minio"
-    ["MONITOR"]="monitor"
-    ["NSQ"]="nsqd"
-    ["POSTGRES"]="database"
-    ["REDIS"]="redis"
-    ["REGISTRY"]="registry"
-    ["REGISTRY_PROXY"]="registry-proxy"
-    ["REGISTRY_TOKEN_REFRESHER"]="registry-token-refresher"
-    ["ROUTER"]="router"
-    ["SLUGBUILDER"]="slugbuilder"
-    ["SLUGRUNNER"]="slugrunner"
-    ["WORKFLOW_MANAGER"]="workflow-manager"
-  )
-
-  for component in "${!component_to_chart_map[@]}"
-  do
-    actual_tag="${component}_GIT_TAG"
-
-    # if <COMPONENT>_GIT_TAG is set to a non-null/non-empty value
-    if [ -n "${!actual_tag}" ]; then
-      component_chart="${component_to_chart_map[${component}]}"
-      value_to_set="${component_chart}.docker_tag=${!actual_tag}"
-
-      if [ -z "${values_to_set}" ]; then
-        values_to_set="${value_to_set}"
-      else
-        values_to_set="${values_to_set},${value_to_set}"
-      fi
-    fi
-  done
-
-  echo "${values_to_set}"
 }

--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -1,40 +1,5 @@
 #!/bin/bash
 
-# Check to see if deis is installed, if so uninstall it.
-clean_cluster() {
-  kubectl get pods --namespace=deis | grep -q deis-controller
-  if [ $? -eq 0 ]; then
-    echo "Deis was installed so I'm removing it!"
-    kubectl delete namespace "deis" &> /dev/null
-
-    local timeout_secs=${DEFAULT_TIMEOUT_SECS:-180}
-    local increment_secs=1
-    local waited_time=0
-
-    echo "Waiting for namespace to go away!"
-    while [ ${waited_time} -lt "${timeout_secs}" ]; do
-      kubectl get ns | grep -q deis
-      if [ $? -gt 0 ]; then
-        echo
-        return 0
-      fi
-
-      sleep ${increment_secs}
-      (( waited_time += increment_secs ))
-
-      if [ ${waited_time} -ge "${timeout_secs}" ]; then
-        echo "Namespace was never deleted"
-        delete-lease
-        exit 1
-      fi
-      echo -n . 1>&2
-    done
-  elif [ $? -eq 1 ]; then
-    echo "Cluster already clean."
-    return 0
-  fi
-}
-
 # install the kubernetes helm binary.
 install_helm() {
   local helm_version=${HELM_VERSION:-canary}
@@ -78,4 +43,76 @@ wait-for-tiller-pod-ready() {
 
     echo -n . 1>&2
   done
+}
+
+# get-chart-repo simply returns '<chart>-<repo_type>', stripping `-production` if
+# repo_type is 'production'
+function get-chart-repo {
+  chart="${1}"
+  repo_type="${2}"
+
+  echo "${chart}-${repo_type}" | sed -e 's/-production//g'
+}
+
+# set-chart-values constructs a list of chart values to set based on the presence
+# of <COMPONENT>_SHA env vars.  The resulting values_to_set can then be used
+# when installing the chart provided as the argument (supports workflow and
+# workflow-e2e).
+function set-chart-values {
+  local chart="${1}"
+
+  declare -A component_to_chart_map
+  case "${chart}" in
+    'workflow')
+      component_to_chart_map=(
+        ["BUILDER"]="builder"
+        ["CONTROLLER"]="controller"
+        ["DOCKERBUILDER"]="dockerbuilder"
+        ["FLUENTD"]="fluentd"
+        ["LOGGER"]="logger"
+        ["MINIO"]="minio"
+        ["MONITOR"]="monitor"
+        ["NSQ"]="nsqd"
+        ["POSTGRES"]="database"
+        ["REDIS"]="redis"
+        ["REGISTRY"]="registry"
+        ["REGISTRY_PROXY"]="registry-proxy"
+        ["REGISTRY_TOKEN_REFRESHER"]="registry-token-refresher"
+        ["ROUTER"]="router"
+        ["SLUGBUILDER"]="slugbuilder"
+        ["SLUGRUNNER"]="slugrunner"
+        ["WORKFLOW_MANAGER"]="workflow-manager"
+      )
+    ;;
+
+    'workflow-e2e')
+      component_to_chart_map=(["WORKFLOW_E2E"]="workflow-e2e")
+    ;;
+  esac
+
+  local values_to_set
+  for component in "${!component_to_chart_map[@]}"
+  do
+    env_var_key="${component}_SHA"
+    env_var_value="${!env_var_key}"
+
+    if [ -n "${env_var_value}" ]; then
+      component_chart="${component_to_chart_map[${component}]}"
+      value_to_set="docker_tag=git-${env_var_value:0:7}"
+
+      if [ "${component_chart}" != "workflow-e2e" ]; then
+        value_to_set="${component_chart}.${value_to_set}"
+      fi
+
+      if [ -z "${values_to_set}" ]; then
+        values_to_set="${value_to_set}"
+      else
+        values_to_set="${values_to_set},${value_to_set}"
+      fi
+    fi
+  done
+
+  if [ -n "${values_to_set}" ]; then
+    echo "--set ${values_to_set}"
+  fi
 }

--- a/tests/deis_test.bats
+++ b/tests/deis_test.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/deis.sh"
+  load stub
+  load stubs/tpl/kubectl
+}
+
+teardown() {
+  rm_stubs
+}
+
+@test "clean_cluster : cluster already clean" {
+  pods_output="foo"
+  ns_output="bar"
+  stub kubectl "$(generate ${pods_output} ${ns_output})" 0
+
+  run clean_cluster
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "Cluster already clean." ]
+}
+
+@test "clean_cluster : cluster not clean and namespaces go away" {
+  pods_output="deis-controller"
+  ns_output="bar"
+  stub kubectl "$(generate ${pods_output} ${ns_output})" 0
+
+  run clean_cluster
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "Deis was installed so I'm removing it!" ]
+  [ "${lines[1]}" = "Waiting for namespace to go away!" ]
+}
+
+@test "clean_cluster : cluster not clean and namespaces don't go away" {
+  export DEFAULT_TIMEOUT_SECS=1
+  stub delete-lease
+
+  pods_output="deis-controller"
+  ns_output="deis"
+  stub kubectl "$(generate ${pods_output} ${ns_output})" 0
+
+  run clean_cluster
+  echo "${output}"
+  [ "${status}" -eq 1 ]
+  [ "${lines[0]}" = "Deis was installed so I'm removing it!" ]
+  [ "${lines[1]}" = "Waiting for namespace to go away!" ]
+  [ "${lines[2]}" = "Namespace was never deleted" ]
+}

--- a/tests/functions_test.bats
+++ b/tests/functions_test.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+# helmc-remove (entire file)
+
 setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/functions.sh"
 }
@@ -40,44 +42,4 @@ setup() {
   [ "${#lines[@]}" -eq 2 ]
   [ "${lines[0]}" == "Setting ${repos[0]}_GIT_TAG to git-${FOO_REPO_SHA:0:7}" ]
   [ "${lines[1]}" == "Setting ${repos[1]}_GIT_TAG to git-${BAR_REPO_SHA:0:7}" ]
-}
-
-@test "set-chart-values-from-env : none in env" {
-  run set-chart-values-from-env
-
-  [ "${status}" -eq 0 ]
-  [ "${output}" = "" ]
-}
-
-@test "set-chart-values-from-env : one in env" {
-  POSTGRES_GIT_TAG='git-abc1234'
-  run set-chart-values-from-env
-
-  [ "${status}" -eq 0 ]
-  [ "${output}" = "database.docker_tag=git-abc1234" ]
-}
-
-@test "set-chart-values-from-env : multiple in env" {
-  POSTGRES_GIT_TAG='git-abc1234'
-  NSQ_GIT_TAG='git-def5678'
-  CONTROLLER_GIT_TAG='git-ghi9123'
-  FOO_GIT_TAG='git-xxx0000'
-  run set-chart-values-from-env
-
-  [ "${status}" -eq 0 ]
-  [ "${output}" = "nsqd.docker_tag=git-def5678,database.docker_tag=git-abc1234,controller.docker_tag=git-ghi9123" ]
-}
-
-@test "get-chart-repo : non-production" {
-  run get-chart-repo 'foo' 'dev'
-
-  [ "${status}" -eq 0 ]
-  [ "${output}" == 'foo-dev' ]
-}
-
-@test "get-chart-repo : production" {
-  run get-chart-repo 'foo' 'production'
-
-  [ "${status}" -eq 0 ]
-  [ "${output}" == 'foo' ]
 }


### PR DESCRIPTION
All helmc-related code has been marked with `helmc-remove` for removal
when support is deprecated.  (Kubernetes) Helm made default; flag changed to USE_HELM_CLASSIC until transition is finished.

Requires https://github.com/deis/jenkins-jobs/pull/292 to pass ci