### PR TITLE
feat(*): add set-chart-version function

### DIFF
--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -7,7 +7,7 @@ install_helm() {
   # Download CLI, retry up to 5 times with 10 second delay between each
   echo "Installing Helm CLI version '${helm_version}' via url '${url}'"
   curl -f --silent --show-error --retry 5 --retry-delay 10 -O "${url}"
-  tar -zxvf helm-"${HELM_VERSION}"-linux-amd64.tar.gz
+  tar -zxvf helm-"${helm_version}"-linux-amd64.tar.gz
   export PATH="linux-amd64:${PATH}"
   export HELM_HOME=/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER
 
@@ -52,6 +52,27 @@ function get-chart-repo {
   repo_type="${2}"
 
   echo "${chart}-${repo_type}" | sed -e 's/-production//g'
+}
+
+# set-chart-version constructs a version flag for use on helm install, depending
+# on the presence of the appropriate env var (supports workflow and workflow-e2e)
+function set-chart-version {
+  local chart="${1}"
+
+  local version_to_set
+  case "${chart}" in
+    'workflow')
+      version_to_set="${WORKFLOW_TAG}"
+      ;;
+    'workflow-e2e')
+      version_to_set="${WORKFLOW_E2E_TAG}"
+      ;;
+  esac
+
+  if [ -n "${version_to_set}" ]; then
+    echo "Installing ${chart} chart ${chart}-${version_to_set}" >&2
+    echo "--version ${version_to_set}"
+  fi
 }
 
 # set-chart-values constructs a list of chart values to set based on the presence

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -30,9 +30,9 @@ then
   echo "Adding workflow chart repo '${chart_repo}'"
   helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 
-  echo "Installing chart workflow-${WORKFLOW_TAG}"
-  helm install "${chart_repo}"/workflow --version="${WORKFLOW_TAG}" \
-    --namespace=deis "$(set-chart-values workflow)"
+  # shellcheck disable=SC2046
+  helm install "${chart_repo}"/workflow --namespace=deis \
+    $(set-chart-version workflow) $(set-chart-values workflow)
 else # helmc-remove
   # Get Helm up to date and checkout branch if needed
   echo "Adding repo ${HELM_REMOTE_REPO}"
@@ -68,9 +68,9 @@ then
   echo "Adding workflow-e2e chart repo '${chart_repo}'"
   helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 
-  echo "Installing workflow-e2e chart workflow-e2e-${WORKFLOW_E2E_TAG}"
-  helm install "${chart_repo}"/workflow-e2e --version="${WORKFLOW_E2E_TAG}" \
-    --namespace=deis "$(set-chart-values workflow-e2e)"
+  # shellcheck disable=SC2046
+  helm install "${chart_repo}"/workflow-e2e --namespace=deis \
+    $(set-chart-version workflow-e2e) $(set-chart-values workflow-e2e)
 else # helmc-remove
   echo "Installing workflow-e2e chart ${WORKFLOW_E2E_CHART}"
   cd "${DEIS_CHART_HOME}" || exit

--- a/tests/helm_test.bats
+++ b/tests/helm_test.bats
@@ -4,11 +4,36 @@ setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/helm.sh"
 }
 
+@test "set-chart-version : none in env" {
+  run set-chart-version
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "" ]
+}
+
+@test "set-chart-version : workflow" {
+  WORKFLOW_TAG="v1.2.3"
+  run set-chart-version workflow
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" == "Installing workflow chart workflow-v1.2.3" ]
+  [ "${lines[1]}" == "--version v1.2.3" ]
+}
+
+@test "set-chart-version : workflow-e2e" {
+  WORKFLOW_E2E_TAG="v1.2.3"
+  run set-chart-version workflow-e2e
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" == "Installing workflow-e2e chart workflow-e2e-v1.2.3" ]
+  [ "${lines[1]}" == "--version v1.2.3" ]
+}
+
 @test "set-chart-values : none in env" {
   run set-chart-values
 
   [ "${status}" -eq 0 ]
-  [ "${output}" = "" ]
+  [ "${output}" == "" ]
 }
 
 @test "set-chart-values : workflow, one in env" {
@@ -16,7 +41,7 @@ setup() {
   run set-chart-values workflow
 
   [ "${status}" -eq 0 ]
-  [ "${output}" = "--set database.docker_tag=git-abc1234" ]
+  [ "${output}" == "--set database.docker_tag=git-abc1234" ]
 }
 
 @test "set-chart-values : workflow, multiple in env" {
@@ -27,7 +52,7 @@ setup() {
   run set-chart-values workflow
 
   [ "${status}" -eq 0 ]
-  [ "${output}" = "--set nsqd.docker_tag=git-def5678,database.docker_tag=git-abc1234,controller.docker_tag=git-ghi9123" ]
+  [ "${output}" == "--set nsqd.docker_tag=git-def5678,database.docker_tag=git-abc1234,controller.docker_tag=git-ghi9123" ]
 }
 
 @test "set-chart-values : workflow-e2e" {
@@ -35,7 +60,7 @@ setup() {
   run set-chart-values workflow-e2e
 
   [ "${status}" -eq 0 ]
-  [ "${output}" = "--set docker_tag=git-abc1234" ]
+  [ "${output}" == "--set docker_tag=git-abc1234" ]
 }
 
 @test "get-chart-repo : non-production" {


### PR DESCRIPTION
To construct a `--version` flag depending on presence of appropriate env var
(if not present, no `--version` flag will be used; therefore the latest version
from the chart repo will be used)

requires https://github.com/deis/jenkins-jobs/pull/296