### PR TITLE
fix(scripts/config.sh): remove chart name defaults

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -17,8 +17,6 @@ export HELM_REMOTE_REPO="${HELM_REMOTE_REPO:-https://github.com/deis/charts.git}
 export DEIS_CHART_HOME=$HELMC_HOME/cache/deis
 export WORKFLOW_BRANCH="${WORKFLOW_BRANCH:-master}"
 export WORKFLOW_E2E_BRANCH="${WORKFLOW_E2E_BRANCH:-master}"
-export WORKFLOW_CHART="${WORKFLOW_CHART:-workflow-dev}"
-export WORKFLOW_E2E_CHART="${WORKFLOW_E2E_CHART:-workflow-dev-e2e}"
 
 repos=(
   "BUILDER"


### PR DESCRIPTION
jenkins jobs themselves are expected to export appropriately if they are needed (see https://github.com/deis/jenkins-jobs/blob/master/bash/scripts/run_e2e.sh#L9-L10)
(will be removed entirely when helm-classic support is deprecated)