### PR TITLE
feat(deis.sh): get-pod-logs() fetches all pod logs

### DIFF
--- a/scripts/deis.sh
+++ b/scripts/deis.sh
@@ -128,9 +128,9 @@ wait-for-router() {
 }
 
 get-pod-logs() {
-  pods=$(kubectl get pods --namespace=deis | sed '1d' | awk '{print $1}')
-  while read -r pod; do
-    kubectl logs "${pod}" --namespace=deis >> "${DEIS_LOG_DIR}/${pod}.log"
-    kubectl logs "${pod}" -p --namespace=deis >> "${DEIS_LOG_DIR}/${pod}-previous.log"
+  pods=$(kubectl get pods --all-namespaces | sed '1d' | awk '{print $1, $2}')
+  while read -r namespace pod; do
+    kubectl logs "${pod}" --namespace="${namespace}" >> "${DEIS_LOG_DIR}/${namespace}-${pod}.log"
+    kubectl logs "${pod}" -p --namespace="${namespace}" >> "${DEIS_LOG_DIR}/${namespace}-${pod}-previous.log"
   done <<< "$pods"
 }


### PR DESCRIPTION
This will allow us to view pod logs from both tiller, anything in kube-system and
application pod logs.

This will help us in debugging why sometimes the following test case fails:

> git push deis master with an existing user who has added their public key and who has a local git repo containing buildpack source code and has run `deis apps:create`