### PR TITLE
fix(scripts/run_e2e): set registration_mode=enabled to keep tests happy

### DIFF
--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -7,7 +7,8 @@ helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 
 # shellcheck disable=SC2046
 helm install "${chart_repo}"/workflow --namespace=deis \
-  $(set-chart-version workflow) $(set-chart-values workflow)
+  $(set-chart-version workflow) $(set-chart-values workflow) --set controller.registration_mode=enabled
+# TODO: remove this "registration_mode" override when e2e tests expect "admin_only" as the default
 
 dump-logs && deis-healthcheck
 


### PR DESCRIPTION
I expect deis/workflow#758 to break the expectations of several end-to-end tests. This patches things up to keep them running until we can refactor e2e tests to expect `registration_mode=admin_only` as the default setting.