### PR TITLE
fix(scripts/run_upgrade.sh): set reg mode on upgrade

### DIFF
--- a/scripts/run_upgrade.sh
+++ b/scripts/run_upgrade.sh
@@ -14,8 +14,7 @@ done
 echo "Installing Workflow chart from the '${ORIGIN_WORKFLOW_REPO}' chart repo..."
 # shellcheck disable=SC2046
 helm install "${ORIGIN_WORKFLOW_REPO}"/workflow --namespace=deis \
-  $(set-chart-version workflow) $(set-chart-values workflow) --set controller.registration_mode=enabled
-# TODO: remove this "registration_mode" override when e2e tests expect "admin_only" as the default
+  $(set-chart-version workflow) $(set-chart-values workflow)
 release="$(helm ls --date --short | tail -n 1)"
 helm ls "${release}"
 
@@ -45,7 +44,8 @@ fi
 # Upgrade release
 echo "Upgrading release ${release} using the latest chart from the '${UPGRADE_WORKFLOW_REPO}' chart repo."
 # shellcheck disable=SC2046
-helm upgrade "${release}" "${UPGRADE_WORKFLOW_REPO}"/workflow $(set-chart-values workflow)
+helm upgrade "${release}" "${UPGRADE_WORKFLOW_REPO}"/workflow $(set-chart-values workflow) --set controller.registration_mode=enabled
+# TODO: remove this "registration_mode" override when e2e tests expect "admin_only" as the default
 helm ls "${release}"
 
 dump-logs && deis-healthcheck


### PR DESCRIPTION
if we are running e2e post-upgrade, the value must be set during upgrade (it does not persist from original install)