### PR TITLE
fix(run_e2e): delete cluster lease after a run

### DIFF
--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -31,10 +31,12 @@ tail_logs_from_e2e_pod
 podExitCode=$?
 echo "Test pod exited with code:${podExitCode}"
 
-#Collect artifacts
+# Collect artifacts
 retrive-artifacts
 retrieveArtifactsExitCode=$?
 echo "Retrieving artifacts exited with code:${retrieveArtifactsExitCode}"
+
+delete-lease
 
 if [ "$podExitCode" -ne "0" ]; then
   echo "Received a non-zero exit code from the e2e test pod..."


### PR DESCRIPTION
In #90 we tore out all the pod polling logic in favour of `helm install --wait`, but forgot to re-add the `delete-lease` function which allows us to clean up the cluster's state after a run.

As seen in deis/controller#1243