### PR TITLE
chore(scripts): '--devel' needed as of helm v2.4.2 for installing 'pre-release' charts

### DIFF
--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -5,7 +5,7 @@ chart_repo="$(get-chart-repo workflow "${CHART_REPO_TYPE}")"
 echo "Adding workflow chart repo '${chart_repo}'"
 helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 
-install_cmd="helm install --wait ${chart_repo}/workflow --namespace=deis \
+install_cmd="helm install --wait --devel ${chart_repo}/workflow --namespace=deis \
 $(set-chart-version workflow) $(set-chart-values workflow)"
 # execute in subshell to print full command being run
 if ! (set -x; eval "${install_cmd}"); then
@@ -19,7 +19,7 @@ chart_repo="$(get-chart-repo workflow-e2e "${CHART_REPO_TYPE}")"
 echo "Adding workflow-e2e chart repo '${chart_repo}'"
 helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 
-install_cmd="helm install --wait ${chart_repo}/workflow-e2e --namespace=deis \
+install_cmd="helm install --wait --devel ${chart_repo}/workflow-e2e --namespace=deis \
 $(set-chart-version workflow-e2e) $(set-chart-values workflow-e2e)"
 # execute in subshell to print full command being run
 if ! (set -x; eval "${install_cmd}"); then

--- a/scripts/run_upgrade.sh
+++ b/scripts/run_upgrade.sh
@@ -11,7 +11,7 @@ for chart_repo in ${chart_repos}; do
   helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 done
 
-install_cmd="helm install --wait ${ORIGIN_WORKFLOW_REPO}/workflow --namespace=deis \
+install_cmd="helm install --wait --devel ${ORIGIN_WORKFLOW_REPO}/workflow --namespace=deis \
 $(set-chart-version workflow) $(set-chart-values workflow)"
 # execute in subshell to print full command being run
 if ! (set -x; eval "${install_cmd}"); then
@@ -45,7 +45,7 @@ if [ "${STORAGE_TYPE}" != "" ]; then
 fi
 
 # Upgrade release
-upgrade_cmd="helm upgrade --wait ${release} ${UPGRADE_WORKFLOW_REPO}/workflow \
+upgrade_cmd="helm upgrade --wait --devel ${release} ${UPGRADE_WORKFLOW_REPO}/workflow \
 $(set-chart-values workflow)"
 # execute in subshell to print full command being run
 if ! (set -x; eval "${upgrade_cmd}"); then
@@ -79,7 +79,7 @@ if [ "${RUN_E2E}" == true ]; then
   helm repo add "${chart_repo}" https://charts.deis.com/"${chart_repo}"
 
   # shellcheck disable=SC2046
-  helm install --wait "${chart_repo}"/workflow-e2e --namespace=deis \
+  helm install --wait --devel "${chart_repo}"/workflow-e2e --namespace=deis \
     $(set-chart-version workflow-e2e) $(set-chart-values workflow-e2e)
 
   echo "Running kubectl describe pod workflow-e2e and piping the output to ${DEIS_DESCRIBE}"


### PR DESCRIPTION
This PR will be needed when we update ci (deis/jenkins-jobs) to a helm version >= v2.4.2.  It should not be merged prior to this; therefore, keeping at `in progress` for now, though all changes have been made.

See https://github.com/kubernetes/helm/releases/tag/v2.4.2 for `--devel` backstory, deets.

Instead of adding logic checking if the chart repo is a pre-release variant (`-dev`, `-pr`, etc.), we can just add the flag everywhere -- it won't hinder grabbing the latest official release from prod/staging repos and will be ignored if an explicit version via `--version` is spec'd.